### PR TITLE
Fix enableAcceleratedNetworking parameter type

### DIFF
--- a/AzureWireGuard/LinuxVirtualMachine.json
+++ b/AzureWireGuard/LinuxVirtualMachine.json
@@ -45,7 +45,7 @@
       }
     },
     "enableAcceleratedNetworking": {
-      "type": "boolean",
+      "type": "bool",
       "defaultValue": false,
       "metadata": {
         "description": "Speeds up network performance, but requires a higher SKU of VM to run."


### PR DESCRIPTION
"boolean" is an invalid type and causes validation to fail when deploying to Azure, as it sets the parameter value to null, for some reason.